### PR TITLE
add custom state to parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,14 @@ Define a type-level parser:
 
 ```haskell
 import Symparsec
-import DeFun.Core
 type PExample = Skip 1 *> Tuple (Isolate 2 NatHex) (Literal "_" *> TakeRest)
 ```
 
 Use it to parse a type-level string (in a GHCi session):
 
 ```haskell
-ghci> :k! Run PExample "xFF_etc"
-Run ...
+ghci> :k! Run' PExample "xFF_etc"
+Run' ...
 = Right '( '(255, "etc"), "")
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,13 +5,27 @@
 * `Isolate n TakeRest` is equivalent to `Take n`
 
 ## Combinators
+* `Fold`. `Foldr`, I guess? Idk.
 * various from parser-combinators, megaparsec. find out the most common/used
 
 ## Example uses of Symparsec to write, present
-### generic-data-functions
-Fiddly and awfully abstract. WIP.
+### Generics, parsing constructor & field names
+* generic-data-functions: done for 1.0. fiddly and awfully abstract. TODO
+* aeson: super real world! do constructor & field name parsing, instead of
+  `constructorTagModifier` and such. pretty daunting though (nasty generics)
 
-### aeson
-Big but real world. Write some new aeson generics which do type-level
-constructor name parsing, instead of using `constructorTagModifier`. Daunting
-because aeson has complex generics.
+### Something that uses multi-line `Symbol`s
+`MultinelineStrings` in GHC 9.12 works for `Symbol`s too. Think of a nice usage.
+
+### JSON parser
+Big, real world, funny. Roll it by hand (Aeson's parsing is very complex).
+
+## Completed examples
+Just to remind myself what is already attempted.
+
+### Expression parser
+Not very well-written, mind you, but it works. I could probably write a
+`MakeExprParser` like in megaparsec, but it's terribly complex.
+
+### Format string parser
+Directly from typelits-printf, minimal changes.

--- a/TODO.md
+++ b/TODO.md
@@ -14,9 +14,6 @@
 * aeson: super real world! do constructor & field name parsing, instead of
   `constructorTagModifier` and such. pretty daunting though (nasty generics)
 
-### Something that uses multi-line `Symbol`s
-`MultinelineStrings` in GHC 9.12 works for `Symbol`s too. Think of a nice usage.
-
 ### JSON parser
 Big, real world, funny. Roll it by hand (Aeson's parsing is very complex).
 
@@ -29,3 +26,6 @@ Not very well-written, mind you, but it works. I could probably write a
 
 ### Format string parser
 Directly from typelits-printf, minimal changes.
+
+### Something that uses multi-line `Symbol`s
+Threw into the expression parser. 9.12 exclusive due to `MultinelineStrings`.

--- a/TODO.md
+++ b/TODO.md
@@ -5,8 +5,7 @@
 * `Isolate n TakeRest` is equivalent to `Take n`
 
 ## Combinators
-* `Choice :: [PParser a] -> PParser a`
-* various from parser-combinators, megaparsec (e.g. `sepBy`)
+* various from parser-combinators, megaparsec. find out the most common/used
 
 ## Example uses of Symparsec to write, present
 ### generic-data-functions

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,6 @@
 # Symparsec to-dos
+* custom state necessitates `TypeAbstractions` (GHC 9.8) sometimes: clarify
+
 ## Proofs (tests?)
 * `Isolate n TakeRest` is equivalent to `Take n`
 

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -26,6 +26,9 @@ the term-level type directly. That's fine.
     `representation` but that's it, so I consider it fairly unambiguous
 * parser state: `ps`
 * parser state custom state: `s`
+  * TODO. term/type s/s is fine because separate namespaces, but type/kind s/s
+    doesn't work, so I need to use type/kind custom/s. I should do the same for
+    all uses. TODO annoying refactor. maybe use `cst` if you want shorter?
 * parser state index: `idx`
   * simple, obvious
 * parser error: `e`

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -16,15 +16,16 @@ defunctionalized arrow. This means some promoted types might not actually use
 the term-level type directly. That's fine.
 
 ## Binders
-* parser string type binder: `str`
+* parser state string type: `str`
   * don't use `sym`.
-* parser return type binder: `a`
-* parser reply type binder: `rep`
+* parser state numeric type: `n`
+  * slightly preferred over `i` because it's a `Natural`
+* parser return type: `a`
+* parser reply: `rep`
   * ? `r` is fine, but it's often used for continuations. `rep` sounds like
     `representation` but that's it, so I consider it fairly unambiguous
-* parser state type binder: `s`
-* parser state index type binder: `idx`
+* parser state: `ps`
+* parser state custom state: `s`
+* parser state index: `idx`
   * simple, obvious
-* parser state number kind binder: `n`
-  * slightly preferred over `i` because it's a `Natural`
-* parser error type binder: `e`
+* parser error: `e`

--- a/src/Symparsec.hs
+++ b/src/Symparsec.hs
@@ -5,7 +5,7 @@ I suggest importing this module qualified. Or, consider the following imports:
 @
 import "Symparsec.Run" qualified as Symparsec
 import "Symparsec.Parsers" qualified as P
--- > :k! Symparsec.Run (P.Take 1) "hello"
+-- > :k! Symparsec.'Run'' (P.Take 1) "hello"
 @
 -}
 
@@ -13,7 +13,9 @@ module Symparsec
   (
   -- * Base definitions
     type Run
+  , type Run'
   , type RunTest
+  , type RunTest'
 
   -- * Parsers
   , module Symparsec.Parsers

--- a/src/Symparsec/Parser/Alternative.hs
+++ b/src/Symparsec/Parser/Alternative.hs
@@ -20,22 +20,22 @@ import qualified Singleraeh.List as List
 -- Does not backtrack. Wrap parsers with 'Symparsec.Parser.Try' as needed.
 --
 -- TODO shitty errors
-type (<|>) :: PParser a -> PParser a -> PParser a
+type (<|>) :: PParser s a -> PParser s a -> PParser s a
 infixl 3 <|>
-data (<|>) l r s
-type instance App (l <|> r) s = Plus r (l @@ s)
-type Plus :: PParser a -> PReply a -> PReply a
+data (<|>) l r ps
+type instance App (l <|> r) ps = Plus r (l @@ ps)
+type Plus :: PParser s a -> PReply s a -> PReply s a
 type family Plus r rep where
-    Plus r ('Reply (OK   a) s) = 'Reply (OK a) s
-    Plus r ('Reply (Err _e) s) = r @@ s
+    Plus r ('Reply (OK   a) ps) = 'Reply (OK a) ps
+    Plus r ('Reply (Err _e) ps) = r @@ ps
 
 -- | 'Control.Alternative.empty' for parsers. Immediately fail with no consumption.
-type Empty :: PParser a
-data Empty s
-type instance App Empty s = 'Reply (Err (Error1 "called empty parser")) s
+type Empty :: PParser s a
+data Empty ps
+type instance App Empty ps = 'Reply (Err (Error1 "called empty parser")) ps
 
 -- | 'Control.Alternative.optional' for parsers.
-type Optional :: PParser a -> PParser (Maybe a)
+type Optional :: PParser s a -> PParser s (Maybe a)
 type Optional p = Con1 Just <$> p <|> Pure Nothing
 
 {- Wow, I guess that works. But also, the manual version:
@@ -50,15 +50,15 @@ type family OptionalEnd rep where
 -- | 'Control.Alternative.many' for parsers.
 --
 -- Does not backtrack. Wrap parsers with 'Symparsec.Parser.Try' as needed.
-type Many :: PParser a -> PParser [a]
-data Many p s
-type instance App (Many p) s = Many' p '[] (p @@ s)
+type Many :: PParser s a -> PParser s [a]
+data Many p ps
+type instance App (Many p) ps = Many' p '[] (p @@ ps)
 type family Many' p as rep where
-    Many' p as ('Reply (OK   a) s) = Many' p (a:as) (p @@ s)
-    Many' p as ('Reply (Err _e) s) = 'Reply (OK (List.Reverse as)) s
+    Many' p as ('Reply (OK   a) ps) = Many' p (a:as) (p @@ ps)
+    Many' p as ('Reply (Err _e) ps) = 'Reply (OK (List.Reverse as)) ps
 
 -- | 'Control.Alternative.some' for parsers.
 --
 -- Does not backtrack. Wrap parsers with 'Symparsec.Parser.Try' as needed.
-type Some :: PParser a -> PParser [a]
+type Some :: PParser s a -> PParser s [a]
 type Some p = LiftA2 (Con2 '(:)) p (Many p)

--- a/src/Symparsec/Parser/Common.hs
+++ b/src/Symparsec/Parser/Common.hs
@@ -45,17 +45,17 @@ import GHC.TypeError qualified as TE
 --
 -- If at end of the string, the state is returned untouched, and @len@ is
 -- guaranteed to be 0.
-type UnconsState :: PState -> (Maybe Char, PState)
-type family UnconsState s where
-    UnconsState ('State rem 0   idx) = '(Nothing, 'State rem 0 idx)
-    UnconsState ('State rem len idx) = UnconsState' (UnconsSymbol rem) len idx
+type UnconsState :: PState s -> (Maybe Char, PState s)
+type family UnconsState ps where
+    UnconsState ('State s rem 0   idx) = '(Nothing, 'State s rem 0 idx)
+    UnconsState ('State s rem len idx) = UnconsState' s (UnconsSymbol rem) len idx
 
 type UnconsState'
-    :: Maybe (Char, Symbol) -> Natural -> Natural -> (Maybe Char, PState)
-type family UnconsState' mstr len idx where
-    UnconsState' (Just '(ch, rem)) len idx =
-        '(Just ch, 'State rem (len-1) (idx+1))
-    UnconsState' Nothing           len idx =
+    :: s -> Maybe (Char, Symbol) -> Natural -> Natural -> (Maybe Char, PState s)
+type family UnconsState' s mstr len idx where
+    UnconsState' s (Just '(ch, rem)) len idx =
+        '(Just ch, 'State s rem (len-1) (idx+1))
+    UnconsState' s Nothing           len idx =
         -- TODO could I change this to a regular parser error? should I?
         TE.TypeError (TE.Text "unrecoverable parser error: got to end of input string before len=0")
 

--- a/src/Symparsec/Parser/Count.hs
+++ b/src/Symparsec/Parser/Count.hs
@@ -8,17 +8,17 @@ import qualified Singleraeh.List as List
 -- TODO Could possibly make more efficient.
 
 -- | @'Count' n p@ parses @n@ occurrences of @p@.
-type Count :: Natural -> PParser a -> PParser [a]
-data Count n p s
-type instance App (Count n p) s = CountLoop p '[] n s
+type Count :: Natural -> PParser s a -> PParser s [a]
+data Count n p ps
+type instance App (Count n p) ps = CountLoop p '[] n ps
 
-type family CountLoop p as n s where
-    CountLoop p as 0 s = 'Reply (OK (List.Reverse as)) s
-    CountLoop p as n s = CountLoopWrap p as n (p @@ s)
+type family CountLoop p as n ps where
+    CountLoop p as 0 ps = 'Reply (OK (List.Reverse as)) ps
+    CountLoop p as n ps = CountLoopWrap p as n (p @@ ps)
 
 type family CountLoopWrap p as n rep where
-    CountLoopWrap p as n ('Reply (OK  a) s) =
-        CountLoop p (a:as) (n-1) s
-    CountLoopWrap p as n ('Reply (Err e) s) =
+    CountLoopWrap p as n ('Reply (OK  a) ps) =
+        CountLoop p (a:as) (n-1) ps
+    CountLoopWrap p as n ('Reply (Err e) ps) =
         -- TODO am I passing the wrong state back here?
-        'Reply (Err e) s
+        'Reply (Err e) ps

--- a/src/Symparsec/Parser/Ensure.hs
+++ b/src/Symparsec/Parser/Ensure.hs
@@ -6,11 +6,11 @@ import Symparsec.Parser.Common
 import Symparsec.Utils ( type IfNatLte )
 
 -- | Assert that there are at least @n@ characters remaining. Non-consuming.
-type Ensure :: Natural -> PParser ()
-data Ensure n s
-type instance App (Ensure n) s = Ensure' n s
-type family Ensure' n s where
-    Ensure' n ('State rem len idx) =
+type Ensure :: Natural -> PParser s ()
+data Ensure n ps
+type instance App (Ensure n) ps = Ensure' n ps
+type family Ensure' n ps where
+    Ensure' n ('State s rem len idx) =
         IfNatLte n len
-            ('Reply (OK '()) ('State rem len idx))
-            ('Reply (Err (Error1 (EStrInputTooShort n len))) ('State rem len idx))
+            ('Reply (OK '()) ('State s rem len idx))
+            ('Reply (Err (Error1 (EStrInputTooShort n len))) ('State s rem len idx))

--- a/src/Symparsec/Parser/Eof.hs
+++ b/src/Symparsec/Parser/Eof.hs
@@ -5,11 +5,11 @@ module Symparsec.Parser.Eof ( type Eof ) where
 import Symparsec.Parser.Common
 
 -- | Assert end of input, or fail.
-type Eof :: PParser ()
-data Eof s
-type instance App Eof s = Eof' (UnconsState s)
-type family Eof' ms where
-    Eof' '(Nothing,  s) = 'Reply (OK '()) s
-    Eof' '(Just _ch, s) = 'Reply (Err EEof) s
+type Eof :: PParser s ()
+data Eof ps
+type instance App Eof ps = Eof' (UnconsState ps)
+type family Eof' mps where
+    Eof' '(Nothing,  ps) = 'Reply (OK '()) ps
+    Eof' '(Just _ch, ps) = 'Reply (Err EEof) ps
 
 type EEof = Error1 "expected end of string"

--- a/src/Symparsec/Parser/Functor.hs
+++ b/src/Symparsec/Parser/Functor.hs
@@ -10,21 +10,21 @@ import Symparsec.Parser.Common
 import DeFun.Function ( type ConstSym1 )
 
 -- | '<$>' for parsers. Apply the given type function to the result.
-type (<$>) :: (a ~> b) -> PParser a -> PParser b
+type (<$>) :: (a ~> b) -> PParser s a -> PParser s b
 infixl 4 <$>
-data (<$>) f p s
-type instance App (f <$> p) s = FmapEnd f (p @@ s)
+data (<$>) f p ps
+type instance App (f <$> p) ps = FmapEnd f (p @@ ps)
 
 type family FmapEnd f rep where
-    FmapEnd f ('Reply (OK  a) s) = 'Reply (OK  (f @@ a)) s
-    FmapEnd f ('Reply (Err e) s) = 'Reply (Err e)        s
+    FmapEnd f ('Reply (OK  a) ps) = 'Reply (OK  (f @@ a)) ps
+    FmapEnd f ('Reply (Err e) ps) = 'Reply (Err e)        ps
 
 -- | '<$' for parsers. Replace the parser result with the given value.
-type (<$) :: a -> PParser b -> PParser a
+type (<$) :: a -> PParser s b -> PParser s a
 infixl 4 <$
 type a <$ p = ConstSym1 a <$> p
 
 -- | 'Data.Functor.$>' for parsers. Flipped t'Symparsec.Parser.Functor.<$'.
-type ($>) :: PParser a -> b -> PParser b
+type ($>) :: PParser s a -> b -> PParser s b
 infixl 4 $>
 type p $> a = ConstSym1 a <$> p

--- a/src/Symparsec/Parser/Isolate.hs
+++ b/src/Symparsec/Parser/Isolate.hs
@@ -6,39 +6,39 @@ import Symparsec.Parser.Common
 import Symparsec.Utils ( type IfNatLte )
 
 -- TODO can use 'Ensure' to help define this
-type Isolate :: Natural -> PParser a -> PParser a
-data Isolate n p s
-type instance App (Isolate n p) s = Isolate' n p s
-type family Isolate' n p s where
-    Isolate' n p ('State rem len idx) =
+type Isolate :: Natural -> PParser s a -> PParser s a
+data Isolate n p ps
+type instance App (Isolate n p) ps = Isolate' n p ps
+type family Isolate' n p ps where
+    Isolate' n p ('State s rem len idx) =
         -- Could perhaps improve this, since 'OrdCond' probably does similar
         -- work to @len-n@.
         IfNatLte n len
-            (IsolateEnd len n (p @@ ('State rem n idx)))
-            ('Reply (Err (Error1 (EStrInputTooShort n len))) ('State rem len idx))
+            (IsolateEnd len n (p @@ ('State s rem n idx)))
+            ('Reply (Err (Error1 (EStrInputTooShort n len))) ('State s rem len idx))
 
 --type IsolateEnd :: Natural -> ? -> ?
 -- TODO are lenRem/lenConsumed actually good names?
 type family IsolateEnd lenOrig n rep where
     -- isolated parser succeeded and consumed all input:
     -- return success with state updated to have actual remaining length
-    IsolateEnd lenOrig n ('Reply (OK  a) ('State rem 0   idx)) =
-        'Reply (OK  a) ('State rem (lenOrig-n)     idx)
+    IsolateEnd lenOrig n ('Reply (OK  a) ('State s rem 0   idx)) =
+        'Reply (OK  a) ('State s rem (lenOrig-n)     idx)
 
     -- isolated parser failed
-    IsolateEnd lenOrig n ('Reply (Err e) ('State rem len idx)) =
+    IsolateEnd lenOrig n ('Reply (Err e) ('State s rem len idx)) =
         -- TODO add some isolate meta
-        'Reply (Err e) ('State rem (lenOrig-n+len) idx)
+        'Reply (Err e) ('State s rem (lenOrig-n+len) idx)
 
     -- isolated parser succeeded but didn't consume all input
-    IsolateEnd lenOrig n ('Reply (OK _a) ('State rem len idx)) =
-        'Reply (Err (EIsolateIncomplete len)) ('State rem (lenOrig-n+len) idx)
+    IsolateEnd lenOrig n ('Reply (OK _a) ('State s rem len idx)) =
+        'Reply (Err (EIsolateIncomplete len)) ('State s rem (lenOrig-n+len) idx)
 
 type EIsolateIncomplete n = Error1
     (    "isolated parser completed without consuming all input ("
       ++ ShowNatDec n ++ " remaining)" )
 
 -- TODO testing. args flipped because you're more likely to defun the len
-type IsolateSym :: PParser a -> Natural ~> PParser a
+type IsolateSym :: PParser s a -> Natural ~> PParser s a
 data IsolateSym p x
 type instance App (IsolateSym p) n = Isolate n p

--- a/src/Symparsec/Parser/Literal.hs
+++ b/src/Symparsec/Parser/Literal.hs
@@ -25,17 +25,17 @@ type EWrongChar lit chExpect chGot =
 
 type EEof lit = EDuringLit lit "EOF while still parsing literal"
 
-type Literal :: Symbol -> PParser ()
-data Literal lit s
-type instance App (Literal lit) s = LiteralCheckLen lit s (Symbol.Length lit)
+type Literal :: Symbol -> PParser s ()
+data Literal lit ps
+type instance App (Literal lit) ps = LiteralCheckLen lit ps (Symbol.Length lit)
 
 -- now, I could use 'Ensure' here. but we add context to errors here, which I
 -- quite like. perhaps I should provide an @Ensure'@ that lets you add e detail?
-type family LiteralCheckLen lit s n where
-    LiteralCheckLen lit ('State rem len idx) litLen =
+type family LiteralCheckLen lit ps n where
+    LiteralCheckLen lit ('State s rem len idx) litLen =
         IfNatLte litLen len
-            (LiteralStep lit ('State rem len idx))
-            ('Reply (Err (ETooShort lit litLen len)) ('State rem len idx))
+            (LiteralStep lit ('State s rem len idx))
+            ('Reply (Err (ETooShort lit litLen len)) ('State s rem len idx))
 
 type LiteralStep lit s = Literal' lit s (UnconsSymbol lit) (UnconsState s)
 type family Literal' lit sPrev ch ms where

--- a/src/Symparsec/Parser/Monad.hs
+++ b/src/Symparsec/Parser/Monad.hs
@@ -8,11 +8,11 @@ import Symparsec.Parser.Common
 
 -- | '>>=' for parsers. Sequentially compose two parsers, passing the value from
 -- the left parser as an argument to the second.
-type (>>=) :: PParser a -> (a ~> PParser b) -> PParser b
+type (>>=) :: PParser s a -> (a ~> PParser s b) -> PParser s b
 infixl 1 >>=
-data (>>=) l r s
-type instance App (l >>= r) s = BindL r (l @@ s)
-type BindL :: (a ~> PParser b) -> PReply a -> PReply b
+data (>>=) l r ps
+type instance App (l >>= r) ps = BindL r (l @@ ps)
+type BindL :: (a ~> PParser s b) -> PReply s a -> PReply s b
 type family BindL r rep where
-    BindL r ('Reply (OK  a) s) = r @@ a @@ s
-    BindL r ('Reply (Err e) s) = 'Reply (Err e) s
+    BindL r ('Reply (OK  a) ps) = r @@ a @@ ps
+    BindL r ('Reply (Err e) ps) = 'Reply (Err e) ps

--- a/src/Symparsec/Parser/Natural.hs
+++ b/src/Symparsec/Parser/Natural.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Symparsec.Parser.Natural
-  ( type NatBase, type NatBase1
+  ( type NatBase, type NatBase1, type NatBase1Sym
   , type NatDec
   , type NatHex
   , type NatBin
@@ -134,3 +134,7 @@ type family NatBaseWhileLoop base parseDigit psCh ps n chCur mDigit mps where
     NatBaseWhileLoop base parseDigit psCh ps n chCur Nothing      _ =
         -- failed to parse next digit: backtrack and finish
         'Reply (OK n) psCh
+
+type NatBase1Sym :: Natural -> (Char ~> Maybe Natural) -> Natural ~> PParser s Natural
+data NatBase1Sym base parseDigit x
+type instance App (NatBase1Sym base parseDigit) x = NatBase1 base parseDigit x

--- a/src/Symparsec/Parser/Satisfy.hs
+++ b/src/Symparsec/Parser/Satisfy.hs
@@ -5,7 +5,7 @@ module Symparsec.Parser.Satisfy ( type Satisfy, type OneOf, type NoneOf ) where
 import Symparsec.Parser.Common
 
 -- may also be defined using @Token@
-type Satisfy :: (Char ~> Bool) -> PParser Char
+type Satisfy :: (Char ~> Bool) -> PParser s Char
 data Satisfy chPred ps
 type instance App (Satisfy chPred) ps = SatisfyStart chPred ps (UnconsState ps)
 
@@ -19,7 +19,7 @@ type family SatisfyValidate psPrev ps ch res where
     SatisfyValidate psPrev ps ch False =
         'Reply (Err (Error1 "satisfy: char failed predicate")) psPrev
 
-type OneOf :: [Char] -> PParser Char
+type OneOf :: [Char] -> PParser s Char
 type OneOf chs = Satisfy (ElemSym chs)
 
 -- TODO put in singleraeh
@@ -35,7 +35,7 @@ data ElemSym as a
 type instance App (ElemSym as) a = Elem a as
 
 -- may also be defined using @CompSym2 NotSym (ElemSym chs)@
-type NoneOf :: [Char] -> PParser Char
+type NoneOf :: [Char] -> PParser s Char
 --type NoneOf chs = Satisfy (CompSym2 NotSym (ElemSym chs))
 type NoneOf chs = Satisfy (NotElemSym chs)
 

--- a/src/Symparsec/Parser/Skip.hs
+++ b/src/Symparsec/Parser/Skip.hs
@@ -8,14 +8,14 @@ import Symparsec.Parser.Applicative
 import Data.Type.Symbol qualified as Symbol
 
 -- | Skip forward @n@ characters. Fails if fewer than @n@ characters remain.
-type Skip :: Natural -> PParser ()
+type Skip :: Natural -> PParser s ()
 type Skip n = Ensure n *> SkipUnsafe n
 
 -- | Skip forward @n@ characters. @n@ must be less than or equal to the number
 --   of remaining characters. (Fairly unhelpful; use 'Skip' instead.)
-type SkipUnsafe :: Natural -> PParser ()
-data SkipUnsafe n s
-type instance App (SkipUnsafe n) s = SkipUnsafe' n s
-type family SkipUnsafe' n s where
-    SkipUnsafe' n ('State rem len idx) =
-        'Reply (OK '()) ('State (Symbol.Drop n rem) (len-n) (idx+n))
+type SkipUnsafe :: Natural -> PParser s ()
+data SkipUnsafe n ps
+type instance App (SkipUnsafe n) ps = SkipUnsafe' n ps
+type family SkipUnsafe' n ps where
+    SkipUnsafe' n ('State s rem len idx) =
+        'Reply (OK '()) ('State s (Symbol.Drop n rem) (len-n) (idx+n))

--- a/src/Symparsec/Parser/Take.hs
+++ b/src/Symparsec/Parser/Take.hs
@@ -6,27 +6,27 @@ import Symparsec.Parser.Common
 import Singleraeh.Symbol ( type RevCharsToSymbol )
 
 -- | Return the next @n@ characters.
-type Take :: Natural -> PParser Symbol
-data Take n s
-type instance App (Take n) s = Take' '[] n s (UnconsState s)
-type family Take' chs n sPrev s where
-    Take' chs 0 sPrev _             = 'Reply (OK (RevCharsToSymbol chs)) sPrev
-    Take' chs n sPrev '(Just ch, s) = Take' (ch:chs) (n-1) s (UnconsState s)
-    Take' chs n sPrev '(Nothing, s) = 'Reply (Err (ETakeEnd n)) sPrev
+type Take :: Natural -> PParser s Symbol
+data Take n ps
+type instance App (Take n) ps = Take' '[] n ps (UnconsState ps)
+type family Take' chs n psPrev ps where
+    Take' chs 0 psPrev _             = 'Reply (OK (RevCharsToSymbol chs)) psPrev
+    Take' chs n psPrev '(Just ch, ps) = Take' (ch:chs) (n-1) ps (UnconsState ps)
+    Take' chs n psPrev '(Nothing, ps) = 'Reply (Err (ETakeEnd n)) psPrev
 
 type ETakeEnd :: Natural -> PError
 type ETakeEnd n = Error1
     ( "tried to take " ++ ShowNatDec n ++ " chars from empty string" )
 
 -- | 'Take' defunctionalization symbol.
-type TakeSym :: Natural ~> PParser Symbol
+type TakeSym :: Natural ~> PParser s Symbol
 data TakeSym n
 type instance App TakeSym n = Take n
 
 -- | Return the next character.
-type Take1 :: PParser Char
-data Take1 s
-type instance App Take1 s = Take1' s (UnconsState s)
-type family Take1' sPrev s where
-    Take1' sPrev '(Just ch, s) = 'Reply (OK ch) s
-    Take1' sPrev '(Nothing, s) = 'Reply (Err (ETakeEnd 1)) sPrev
+type Take1 :: PParser s Char
+data Take1 ps
+type instance App Take1 ps = Take1' ps (UnconsState ps)
+type family Take1' psPrev ps where
+    Take1' psPrev '(Just ch, ps) = 'Reply (OK ch) ps
+    Take1' psPrev '(Nothing, ps) = 'Reply (Err (ETakeEnd 1)) psPrev

--- a/src/Symparsec/Parser/TakeRest.hs
+++ b/src/Symparsec/Parser/TakeRest.hs
@@ -8,12 +8,12 @@ import qualified Data.Type.Symbol as Symbol
 -- | Consume and return the rest of the input string.
 --
 -- Never fails. May return the empty string.
-type TakeRest :: PParser Symbol
-data TakeRest s
-type instance App TakeRest s = TakeRest' s
-type family TakeRest' s where
-    TakeRest' ('State rem len idx) =
-        'Reply (OK (Symbol.Take len rem)) ('State (Symbol.Drop len rem) 0 (idx+len))
+type TakeRest :: PParser s Symbol
+data TakeRest ps
+type instance App TakeRest ps = TakeRest' ps
+type family TakeRest' ps where
+    TakeRest' ('State s rem len idx) =
+        'Reply (OK (Symbol.Take len rem)) ('State s (Symbol.Drop len rem) 0 (idx+len))
 
 {-
 import GHC.TypeLits

--- a/src/Symparsec/Parser/TakeWhile.hs
+++ b/src/Symparsec/Parser/TakeWhile.hs
@@ -10,25 +10,25 @@ import Singleraeh.Symbol ( type RevCharsToSymbol )
 -- May also be defined via
 -- @'Symparsec.Parser.While.While' chPred 'Symparsec.Parser.TakeRest.TakeRest'@,
 -- but a custom implementation is more efficient.
-type TakeWhile :: (Char ~> Bool) -> PParser Symbol
-data TakeWhile chPred s
-type instance App (TakeWhile chPred) s = TakeWhileStart chPred s (UnconsState s)
+type TakeWhile :: (Char ~> Bool) -> PParser s Symbol
+data TakeWhile chPred ps
+type instance App (TakeWhile chPred) ps = TakeWhileStart chPred ps (UnconsState ps)
 
-type family TakeWhileStart chPred sPrev ms where
-    TakeWhileStart chPred sPrev '(Just ch, s) =
-        TakeWhileLoop chPred sPrev s ch '[] (chPred @@ ch) (UnconsState s)
-    TakeWhileStart chPred sPrev '(Nothing, s) =
-        'Reply (OK "") sPrev
+type family TakeWhileStart chPred psPrev mps where
+    TakeWhileStart chPred psPrev '(Just ch, ps) =
+        TakeWhileLoop chPred psPrev ps ch '[] (chPred @@ ch) (UnconsState ps)
+    TakeWhileStart chPred psPrev '(Nothing, ps) =
+        'Reply (OK "") psPrev
 
-type family TakeWhileLoop chPred sPrev sCh ch taken res ms where
+type family TakeWhileLoop chPred psPrev psCh ch taken res mps where
     -- next char succeeded and not EOF
-    TakeWhileLoop chPred sPrev sCh ch taken True '(Just chNext, s) =
-        TakeWhileLoop chPred sCh s chNext (ch:taken) (chPred @@ chNext) (UnconsState s)
+    TakeWhileLoop chPred psPrev psCh ch taken True '(Just chNext, ps) =
+        TakeWhileLoop chPred psCh ps chNext (ch:taken) (chPred @@ chNext) (UnconsState ps)
 
     -- next char succeeded and EOF: end
-    TakeWhileLoop chPred sPrev sCh ch taken True '(Nothing, s) =
-        'Reply (OK (RevCharsToSymbol (ch:taken))) sCh -- @sCh == s@ should hold
+    TakeWhileLoop chPred sPrev psCh ch taken True '(Nothing, ps) =
+        'Reply (OK (RevCharsToSymbol (ch:taken))) psCh -- @psCh == ps@ should hold
 
     -- next char failed: backtrack and end
-    TakeWhileLoop chPred sPrev sCh ch taken False _ =
-        'Reply (OK (RevCharsToSymbol taken)) sPrev
+    TakeWhileLoop chPred psPrev psCh ch taken False _ =
+        'Reply (OK (RevCharsToSymbol taken)) psPrev

--- a/src/Symparsec/Parser/Token.hs
+++ b/src/Symparsec/Parser/Token.hs
@@ -5,7 +5,7 @@ module Symparsec.Parser.Token ( type Token ) where
 import Symparsec.Parser.Common
 
 -- | Should match @token@ from megaparsec. Backtracks.
-type Token :: (Char ~> Maybe a) -> PParser a
+type Token :: (Char ~> Maybe a) -> PParser s a
 data Token chParse ps
 type instance App (Token chParse) ps = TokenStart chParse ps (UnconsState ps)
 type family TokenStart chParse psPrev mps where

--- a/src/Symparsec/Parser/Try.hs
+++ b/src/Symparsec/Parser/Try.hs
@@ -5,10 +5,10 @@ module Symparsec.Parser.Try ( type Try ) where
 import Symparsec.Parser.Common
 
 -- | Run the given parser, backtracking on error.
-type Try :: PParser a -> PParser a
-data Try p s
-type instance App (Try p) s = Try' s (p @@ s)
-type Try' :: PState -> PReply a -> PReply a
-type family Try' sPrev rep where
-    Try' sPrev ('Reply (OK  a) s) = 'Reply (OK  a) s
-    Try' sPrev ('Reply (Err e) s) = 'Reply (Err e) sPrev
+type Try :: PParser s a -> PParser s a
+data Try p ps
+type instance App (Try p) ps = Try' ps (p @@ ps)
+type Try' :: PState s -> PReply s a -> PReply s a
+type family Try' psPrev rep where
+    Try' psPrev ('Reply (OK  a) ps) = 'Reply (OK  a) ps
+    Try' psPrev ('Reply (Err e) ps) = 'Reply (Err e) psPrev

--- a/src/Symparsec/Parser/While.hs
+++ b/src/Symparsec/Parser/While.hs
@@ -5,28 +5,28 @@ module Symparsec.Parser.While ( type While ) where
 import Symparsec.Parser.Common
 
 -- | Run the given parser while the given character predicate succeeds.
-type While :: (Char ~> Bool) -> PParser a -> PParser a
-data While chPred p s
-type instance App (While chPred p) s = While' chPred p s
+type While :: (Char ~> Bool) -> PParser s a -> PParser s a
+data While chPred p ps
+type instance App (While chPred p) ps = While' chPred p ps
 
-type family While' chPred p s where
-    While' chPred p ('State rem len idx) =
-        WhileCountStart len rem idx chPred p (UnconsSymbol rem)
+type family While' chPred p ps where
+    While' chPred p ('State s rem len idx) =
+        WhileCountStart s len rem idx chPred p (UnconsSymbol rem)
 
-type family WhileCountStart len rem idx chPred p mstr where
-    WhileCountStart len rem idx chPred p (Just '(ch, str)) =
-        WhileCount len rem idx chPred p 0 (UnconsSymbol str) (chPred @@ ch)
-    WhileCountStart len rem idx chPred p Nothing           = p @@ ('State rem 0 idx)
+type family WhileCountStart s len rem idx chPred p mstr where
+    WhileCountStart s len rem idx chPred p (Just '(ch, str)) =
+        WhileCount s len rem idx chPred p 0 (UnconsSymbol str) (chPred @@ ch)
+    WhileCountStart s len rem idx chPred p Nothing           = p @@ ('State s rem 0 idx)
 
-type family WhileCount len rem idx chPred p n mstr res where
-    WhileCount len rem idx chPred p n (Just '(ch, str)) True  =
-        WhileCount len rem idx chPred p (n+1) (UnconsSymbol str) (chPred @@ ch)
-    WhileCount len rem idx chPred p n (Just '(ch, str)) False =
-        WhileEnd (len-n)     (p @@ ('State rem n     idx))
-    WhileCount len rem idx chPred p n Nothing           True  =
-        WhileEnd (len-(n+1)) (p @@ ('State rem (n+1) idx))
-    WhileCount len rem idx chPred p n Nothing           False =
-        WhileEnd (len-n)     (p @@ ('State rem n     idx))
+type family WhileCount s len rem idx chPred p n mstr res where
+    WhileCount s len rem idx chPred p n (Just '(ch, str)) True  =
+        WhileCount s len rem idx chPred p (n+1) (UnconsSymbol str) (chPred @@ ch)
+    WhileCount s len rem idx chPred p n (Just '(ch, str)) False =
+        WhileEnd (len-n)     (p @@ ('State s rem n     idx))
+    WhileCount s len rem idx chPred p n Nothing           True  =
+        WhileEnd (len-(n+1)) (p @@ ('State s rem (n+1) idx))
+    WhileCount s len rem idx chPred p n Nothing           False =
+        WhileEnd (len-n)     (p @@ ('State s rem n     idx))
 
 type family WhileEnd lenRest rep where
     -- TODO note that we don't require that the inner parser fully consumes.
@@ -35,5 +35,5 @@ type family WhileEnd lenRest rep where
     -- but by not requiring full consumption, we recover char-by-char behaviour!
     -- and we can still get full consumption by combining with Isolate.
     -- the inner parser should generally fully consume though, as a design point
-    WhileEnd lenRest ('Reply res ('State rem len idx)) =
-        'Reply res ('State rem (lenRest+len) idx)
+    WhileEnd lenRest ('Reply res ('State s rem len idx)) =
+        'Reply res ('State s rem (lenRest+len) idx)

--- a/src/Symparsec/Parser/While/Predicates.hs
+++ b/src/Symparsec/Parser/While/Predicates.hs
@@ -4,6 +4,7 @@
 
 module Symparsec.Parser.While.Predicates where
 
+import Data.Type.Equality ( type (==) )
 import DeFun.Core
 
 -- | @A-Za-z@
@@ -116,3 +117,7 @@ type family IsDecDigit ch where
 type IsDecDigitSym :: Char ~> Bool
 data IsDecDigitSym ch
 type instance App IsDecDigitSym ch = IsDecDigit ch
+
+type IsChar :: Char -> Char ~> Bool
+data IsChar chTest ch
+type instance App (IsChar chTest) ch = ch == chTest

--- a/src/Symparsec/Parsers.hs
+++ b/src/Symparsec/Parsers.hs
@@ -29,6 +29,7 @@ module Symparsec.Parsers
   , type Try
   , type While
   , type TakeWhile
+  , type TakeWhile1
   , type Count
   , type Token
   , type Satisfy
@@ -40,7 +41,7 @@ module Symparsec.Parsers
   , type Literal
 
   -- ** Naturals
-  , type NatBase
+  , type NatBase, type NatBase1, type NatBase1Sym
   , type NatDec
   , type NatHex
   , type NatBin

--- a/src/Symparsec/Parsers.hs
+++ b/src/Symparsec/Parsers.hs
@@ -11,6 +11,8 @@ module Symparsec.Parsers
   , type (<*>), type Pure, type LiftA2, type (*>), type (<*)
   , type (>>=)
   , type (<|>), type Empty, type Optional, type Many, type Some
+  , type SepBy, type SepBy1
+  , type Choice
 
   -- * Positional
   -- $positional

--- a/src/Symparsec/Run.hs
+++ b/src/Symparsec/Run.hs
@@ -18,7 +18,7 @@ import TypeLevelShow.Natural ( type ShowNatDec )
 -- * On success, returns a tuple of @(result :: a, remaining :: 'Symbol')@.
 -- * On failure, returns an 'TE.ErrorMessage'.
 type Run :: PParser s a -> s -> Symbol -> Either TE.ErrorMessage (a, Symbol)
-type Run p s str = RunEnd str (p @@ StateInit s str)
+type Run p custom str = RunEnd str (p @@ StateInit custom str)
 
 -- | Run a parser on a 'Symbol'. The parser must not use custom state.
 --
@@ -44,10 +44,10 @@ type family RunEnd str rep where
 -- 'TE.TypeError's, printing @= (TypeError ...)@ instead of the error message.
 -- Alas! Instead, do something like @> Proxy \@(RunTest ...)@.
 type RunTest :: PParser s a -> s -> Symbol -> (a, Symbol)
-type RunTest p s str = FromRightTypeError (Run p s str)
+type RunTest p custom str = FromRightTypeError (Run p custom str)
 
 -- | Run a parser on a 'Symbol', emitting a type error on failure.
---   The parser must not use custom state
+--   The parser must not use custom. state
 --
 -- This /would/ be useful for @:k!@ runs, but it doesn't work properly with
 -- 'TE.TypeError's, printing @= (TypeError ...)@ instead of the error message.

--- a/src/Symparsec/Run.hs
+++ b/src/Symparsec/Run.hs
@@ -2,7 +2,7 @@
 
 -- | Running Symparsec parsers.
 
-module Symparsec.Run ( type Run, type RunTest ) where
+module Symparsec.Run ( type Run, type Run', type RunTest, type RunTest' ) where
 
 import Symparsec.Parser
 import Data.Type.Symbol qualified as Symbol
@@ -19,6 +19,13 @@ import TypeLevelShow.Natural ( type ShowNatDec )
 -- * On failure, returns an 'TE.ErrorMessage'.
 type Run :: PParser s a -> s -> Symbol -> Either TE.ErrorMessage (a, Symbol)
 type Run p s str = RunEnd str (p @@ StateInit s str)
+
+-- | Run a parser on a 'Symbol'. The parser must not use custom state.
+--
+-- * On success, returns a tuple of @(result :: a, remaining :: 'Symbol')@.
+-- * On failure, returns an 'TE.ErrorMessage'.
+type Run' :: PParser () a -> Symbol -> Either TE.ErrorMessage (a, Symbol)
+type Run' p str = Run p '() str
 
 type RunEnd :: Symbol -> PReply s a -> Either TE.ErrorMessage (a, Symbol)
 type family RunEnd str rep where
@@ -38,6 +45,15 @@ type family RunEnd str rep where
 -- Alas! Instead, do something like @> Proxy \@(RunTest ...)@.
 type RunTest :: PParser s a -> s -> Symbol -> (a, Symbol)
 type RunTest p s str = FromRightTypeError (Run p s str)
+
+-- | Run a parser on a 'Symbol', emitting a type error on failure.
+--   The parser must not use custom state
+--
+-- This /would/ be useful for @:k!@ runs, but it doesn't work properly with
+-- 'TE.TypeError's, printing @= (TypeError ...)@ instead of the error message.
+-- Alas! Instead, do something like @> Proxy \@(RunTest ...)@.
+type RunTest' :: PParser () a -> Symbol -> (a, Symbol)
+type RunTest' p str = RunTest p '() str
 
 type FromRightTypeError :: Either TE.ErrorMessage a -> a
 type family FromRightTypeError eea where

--- a/src/Symparsec/Run.hs
+++ b/src/Symparsec/Run.hs
@@ -13,31 +13,31 @@ import GHC.TypeError qualified as TE
 import TypeLevelShow.Doc
 import TypeLevelShow.Natural ( type ShowNatDec )
 
--- | Run the given parser on the given 'Symbol'.
+-- | Run a parser with some initial custom state on a 'Symbol'.
 --
 -- * On success, returns a tuple of @(result :: a, remaining :: 'Symbol')@.
 -- * On failure, returns an 'TE.ErrorMessage'.
-type Run :: PParser a -> Symbol -> Either TE.ErrorMessage (a, Symbol)
-type Run p str = RunEnd str (p @@ StateInit str)
+type Run :: PParser s a -> s -> Symbol -> Either TE.ErrorMessage (a, Symbol)
+type Run p s str = RunEnd str (p @@ StateInit s str)
 
-type RunEnd :: Symbol -> PReply a -> Either TE.ErrorMessage (a, Symbol)
+type RunEnd :: Symbol -> PReply s a -> Either TE.ErrorMessage (a, Symbol)
 type family RunEnd str rep where
-    RunEnd str ('Reply (OK  a) ('State  rem _len _idx)) =
+    RunEnd str ('Reply (OK  a) ('State _s  rem _len _idx)) =
         -- TODO I could return only @len@ of the remaining input @rem@, but
         -- that's more work than just returning @rem@, and I don't see a way
         -- this would matter for correct parsers.
         Right '(a, rem)
-    RunEnd str ('Reply (Err e) ('State _rem _len  idx)) =
+    RunEnd str ('Reply (Err e) ('State _s _rem _len  idx)) =
         Left (RenderPDoc (PrettyErrorTop idx str e))
 
--- | Run the given parser on the given 'Symbol', emitting a type error on
---   failure.
+-- | Run a parser with some initial custom state on a 'Symbol',
+--   emitting a type error on failure.
 --
 -- This /would/ be useful for @:k!@ runs, but it doesn't work properly with
 -- 'TE.TypeError's, printing @= (TypeError ...)@ instead of the error message.
 -- Alas! Instead, do something like @> Proxy \@(RunTest ...)@.
-type RunTest :: PParser a -> Symbol -> (a, Symbol)
-type RunTest p str = FromRightTypeError (Run p str)
+type RunTest :: PParser s a -> s -> Symbol -> (a, Symbol)
+type RunTest p s str = FromRightTypeError (Run p s str)
 
 type FromRightTypeError :: Either TE.ErrorMessage a -> a
 type family FromRightTypeError eea where
@@ -45,8 +45,8 @@ type family FromRightTypeError eea where
     FromRightTypeError (Left  e) = TE.TypeError e
 
 -- | Initial parser state for the given 'Symbol'.
-type StateInit :: Symbol -> PState
-type StateInit str = 'State str (Symbol.Length str) 0
+type StateInit :: s -> Symbol -> PState s
+type StateInit s str = 'State s str (Symbol.Length str) 0
 
 -- | Pretty print a top-level parser error.
 --

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -12,10 +12,10 @@ type CstrX_Y = LiftA2 (Con2 '(,))
     (Literal "_"    *> Isolate 2 NatHex)
 
 spec :: Expect
-    '[ Run (Literal "raehik") "raehik" `Is` Right '( '(), "")
-     , Run (Literal "raeh") "raehraeh" `Is` Right '( '(), "raeh")
-     , Run (Skip 3 *> Literal "HI") "...HI" `Is` Right '( '(), "")
-     , Run (Literal "0x" *> NatHex) "0xfF" `Is` Right '( 255, "")
-     , Run CstrX_Y "Cstr12_AB" `Is` Right '( '(12, 0xAB), "")
+    '[ Run' (Literal "raehik") "raehik" `Is` Right '( '(), "")
+     , Run' (Literal "raeh") "raehraeh" `Is` Right '( '(), "raeh")
+     , Run' (Skip 3 *> Literal "HI") "...HI" `Is` Right '( '(), "")
+     , Run' (Literal "0x" *> NatHex) "0xfF" `Is` Right '( 255, "")
+     , Run' CstrX_Y "Cstr12_AB" `Is` Right '( '(12, 0xAB), "")
      ]
 spec = Valid


### PR DESCRIPTION
Having to add custom state in `Run` sucks. But megaparsec is really using a workaround (leveraging monad transformers), and regular parsec _does_ have custom state. I'll just provide some `Run'` utils that instantiate it to `'()`.